### PR TITLE
dependency update 20230822

### DIFF
--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -41,14 +41,14 @@ common opts
 
 common deps
   build-depends:
-    , base                  >=4.12     && <4.18
+    , base                  >=4.12     && <4.19
     , base64-bytestring     >=1.0.0.0  && <1.3
-    , bytestring            >=0.10.8   && <0.12
+    , bytestring            >=0.10.8   && <0.13
     , case-insensitive      ^>=1.2.0.0
     , hal                   >=0.4.7    && <0.4.11 || >=1.0.0 && <1.1
     , http-types            ^>=0.12.3
     , network               >=2.8.0.0  && <3.2
-    , text                  ^>=1.2.3 || ^>=2.0
+    , text                  ^>=1.2.3 || ^>=2.1
     , unordered-containers  ^>=0.2.10.0
     , vault                 ^>=0.3.1.0
     , wai                   ^>=3.2.2
@@ -67,7 +67,7 @@ test-suite wai-handler-hal-tests
   other-modules:      Network.Wai.Handler.HalTest
   build-tool-depends: tasty-discover:tasty-discover ^>=4.2.2
   build-depends:
-    , aeson            >=1.5.6.0 && <1.6 || >=2.0 && <2.2
+    , aeson            >=1.5.6.0 && <1.6 || >=2.0 && <2.3
     , pretty-simple    ^>=4.1.0.0
     , tasty            >=1.3     && <1.5
     , tasty-golden     ^>=2.3

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -48,7 +48,7 @@ common deps
     , hal                   >=0.4.7    && <0.4.11 || >=1.0.0 && <1.1
     , http-types            ^>=0.12.3
     , network               >=2.8.0.0  && <3.2
-    , text                  ^>=1.2.3 || ^>=2.1
+    , text                  ^>=1.2.3 || ^>=2.0
     , unordered-containers  ^>=0.2.10.0
     , vault                 ^>=0.3.1.0
     , wai                   ^>=3.2.2


### PR DESCRIPTION
This is my first attempt updating this repo. I did a `nix flake update` which produced no change, and then a `cabal update` and `cabal outdated` which gave me a list of outdated packages. 

I updated those in the cabal file, and `cabal build` and `cabal test` work perfectly fine, whereas `nix build` when I increased the package bounds for the `text` library.

```
error: builder for '/nix/store/irfna63jv3mzngilyr47yknb03pwcmr0-wai-handler-hal-0.2.0.0.drv' failed with exit code 1;
       last 10 log lines:
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > configureFlags: --verbose --prefix=/nix/store/lqmqrlhckn7y4v1m58cq10q7qp83s38a-wai-handler-hal-0.2.0.0 --libdir=$prefix/lib/$compiler --libsubdir=$abi/$libname --docdir=/nix/store/imz4qv65ci6lf3rjmhfhchg0jivznwlr-wai-handler-hal-0.2.0.0-doc/share/doc/wai-handler-hal-0.2.0.0 --with-gcc=gcc --package-db=/build/tmp.CNgTcnF4P8/package.conf.d --ghc-options=-j16 +RTS -A64M -RTS --disable-split-objs --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --ghc-option=-split-sections --ghc-options=-haddock --extra-lib-dirs=/nix/store/00914xy1p14vd8qy23lrjd165rnxy3h2-ncurses-6.4/lib --extra-lib-dirs=/nix/store/g8l012l0q2xbl27da8zipg39mnpf40gb-libffi-3.4.4/lib --extra-lib-dirs=/nix/store/c6v3ix7r8gy6fgq1jssswkdk4xnk8fwk-gmp-with-cxx-6.2.1/lib
       > Using Parsec parser
       > Configuring wai-handler-hal-0.2.0.0...
       > CallStack (from HasCallStack):
       >   withMetadata, called at libraries/Cabal/Cabal/src/Distribution/Simple/Utils.hs:370:14 in Cabal-3.8.1.0:Distribution.Simple.Utils
       > Error: Setup: Encountered missing or private dependencies:
       > text >=1.2.3 && <1.3 || >=2.1 && <2.2
       >
       For full logs, run 'nix log /nix/store/irfna63jv3mzngilyr47yknb03pwcmr0-wai-handler-hal-0.2.0.0.drv'.
 ```

If someone can help me out on this one, that would be ace. I've reverted the change for the `text` library bounds update and everything builds correctly.