### PR TITLE
Revert "dependency update 20230822"

### DIFF
--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -41,9 +41,9 @@ common opts
 
 common deps
   build-depends:
-    , base                  >=4.12     && <4.19
+    , base                  >=4.12     && <4.18
     , base64-bytestring     >=1.0.0.0  && <1.3
-    , bytestring            >=0.10.8   && <0.13
+    , bytestring            >=0.10.8   && <0.12
     , case-insensitive      ^>=1.2.0.0
     , hal                   >=0.4.7    && <0.4.11 || >=1.0.0 && <1.1
     , http-types            ^>=0.12.3
@@ -67,7 +67,7 @@ test-suite wai-handler-hal-tests
   other-modules:      Network.Wai.Handler.HalTest
   build-tool-depends: tasty-discover:tasty-discover ^>=4.2.2
   build-depends:
-    , aeson            >=1.5.6.0 && <1.6 || >=2.0 && <2.3
+    , aeson            >=1.5.6.0 && <1.6 || >=2.0 && <2.2
     , pretty-simple    ^>=4.1.0.0
     , tasty            >=1.3     && <1.5
     , tasty-golden     ^>=2.3


### PR DESCRIPTION
Reverts bellroy/wai-handler-hal#22

The new bounds don't actually build correctly. I'll be following up with @JackKelly-Bellroy on a resolution here.