### PR TITLE
don't base64-encode html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for wai-handler-hal
 
-## 0.3.0.0 -- 2023-12-16
+## 0.3.0.0 -- 2023-12-17
 
 - Breaking change: add `Options` record parameter to `runWithOptions`,
   `toWaiRequest` and `fromWaiResponse`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for wai-handler-hal
 
+## 0.3.0.0 -- UNRELEASED
+
+- Breaking change: add `Options` record parameter to `runWithOptions`,
+  `toWaiRequest` and `fromWaiResponse`.
+- Provide a `defaultOptions`.
+- Make whether or not to run base64-encoding on the response body customizable
+  through `Options.binaryMimeType`.
+
 ## 0.2.0.0 -- 2023-03-17
 
 - Breaking change: `toWaiRequest` now sorts request headers and query string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for wai-handler-hal
 
-## 0.3.0.0 -- UNRELEASED
+## 0.3.0.0 -- 2023-12-16
 
 - Breaking change: add `Options` record parameter to `runWithOptions`,
   `toWaiRequest` and `fromWaiResponse`.

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -31,6 +31,8 @@
 -- @
 module Network.Wai.Handler.Hal
   ( run,
+    Options (..),
+    defaultOptions,
     runWithContext,
     toWaiRequest,
     fromWaiResponse,
@@ -104,26 +106,58 @@ run ::
   HalRequest.ProxyRequest HalRequest.NoAuthorizer ->
   m HalResponse.ProxyResponse
 run app req = liftIO $ do
-  waiReq <- toWaiRequest Vault.empty 443 req
+  waiReq <- toWaiRequest defaultOptions req
   responseRef <- IORef.newIORef Nothing
   Wai.ResponseReceived <- app waiReq $ \waiResp ->
     Wai.ResponseReceived <$ IORef.writeIORef responseRef (Just waiResp)
   Just waiResp <- IORef.readIORef responseRef
-  fromWaiResponse waiResp
+  fromWaiResponse defaultOptions waiResp
+
+-- | Options that can be used to customize the behaviour of 'runWithContext'.
+-- 'defaultOptions' provides sensible defaults.
+data Options = Options
+  { -- | Vault of values to share between the application and any
+    -- middleware. You can pass in @Data.Vault.Lazy.'Vault.empty'@, or
+    -- 'mempty' if you don't want to depend on @vault@ directly.
+    optionsVault :: Vault
+  , -- | API Gateway doesn't tell us the port it's listening on, so you
+    -- have to tell it yourself. This is almost always going to be 443
+    -- (HTTPS).
+    optionsPortNumber :: PortNumber
+  , -- | Binary responses need to be encoded as base64. This option lets you
+    -- customize which mime types are considered binary data.
+    --
+    -- The following mime types are __not__ considered binary by default:
+    --
+    -- * @application/json@
+    -- * @application/xml@
+    -- * anything starting with @text/@
+    -- * anything ending with @+json@
+    -- * anything ending with @+xml@
+    optionsBinaryMimeType :: Text -> Bool
+  }
+
+-- | Default options for running 'Wai.Application's on Lambda.
+defaultOptions :: Options
+defaultOptions = Options
+  { optionsVault          = Vault.empty
+  , optionsPortNumber     = 443
+  , optionsBinaryMimeType = \mime -> case mime of
+      "application/json"              -> False
+      "application/xml"               -> False
+      _ | "text/" `T.isPrefixOf` mime -> False
+      _ | "+json" `T.isSuffixOf` mime -> False
+      _ | "+xml"  `T.isSuffixOf` mime -> False
+      _                               -> True
+  }
 
 -- | Convert a WAI 'Wai.Application' into a function that can
 -- be run by hal's 'AWS.Lambda.Runtime.mRuntimeWithContext''. This
 -- function exposes all the configurable knobs.
 runWithContext ::
   MonadIO m =>
-  -- | Vault of values to share between the application and any
-  -- middleware. You can pass in @Data.Vault.Lazy.'Vault.empty'@, or
-  -- 'mempty' if you don't want to depend on @vault@ directly.
-  Vault ->
-  -- | API Gateway doesn't tell us the port it's listening on, so you
-  -- have to tell it yourself. This is almost always going to be 443
-  -- (HTTPS).
-  PortNumber ->
+  -- | Configuration options, 'defaultOptions' provides sensible defaults.
+  Options ->
   -- | We pass two 'Vault' keys to the callback that provides the
   -- 'Wai.Application'. This allows the application to look into the
   -- 'Vault' part of each request and read @hal@ data structures, if
@@ -146,19 +180,20 @@ runWithContext ::
   -- an "ambiguous type variable" error at the use site.
   HalRequest.ProxyRequest HalRequest.NoAuthorizer ->
   m HalResponse.ProxyResponse
-runWithContext vault port app ctx req = liftIO $ do
+runWithContext opts app ctx req = liftIO $ do
   contextKey <- Vault.newKey
   requestKey <- Vault.newKey
   let vault' =
-        vault
+        (optionsVault opts)
           & Vault.insert contextKey ctx
           & Vault.insert requestKey req
-  waiReq <- toWaiRequest vault' port req
+      opts' = opts {optionsVault = vault'}
+  waiReq <- toWaiRequest opts' req
   responseRef <- IORef.newIORef Nothing
   Wai.ResponseReceived <- app contextKey requestKey waiReq $ \waiResp ->
     Wai.ResponseReceived <$ IORef.writeIORef responseRef (Just waiResp)
   Just waiResp <- IORef.readIORef responseRef
-  fromWaiResponse waiResp
+  fromWaiResponse opts' waiResp
 
 -- | Convert the request sent to a Lambda serving an API Gateway proxy
 -- integration into a WAI request.
@@ -166,12 +201,12 @@ runWithContext vault port app ctx req = liftIO $ do
 -- __Note:__ We aren't told the HTTP version the client is using, so
 -- we assume HTTP 1.1.
 toWaiRequest ::
-  Vault ->
-  PortNumber ->
+  Options ->
   HalRequest.ProxyRequest a ->
   IO Wai.Request
-toWaiRequest vault port req = do
-  let pathSegments = T.splitOn "/" . T.dropWhile (== '/') $ HalRequest.path req
+toWaiRequest opts req = do
+  let port = optionsPortNumber opts
+      pathSegments = T.splitOn "/" . T.dropWhile (== '/') $ HalRequest.path req
       query = sort . constructQuery $ HalRequest.multiValueQueryStringParameters req
       hints =
         NS.defaultHints
@@ -226,7 +261,7 @@ toWaiRequest vault port req = do
             Wai.pathInfo = pathSegments,
             Wai.queryString = query,
             Wai.requestBody = body,
-            Wai.vault = vault,
+            Wai.vault = optionsVault opts,
             Wai.requestBodyLength =
               Wai.KnownLength . fromIntegral . BL.length $ HalRequest.body req,
             Wai.requestHeaderHost = getHeader hHost req,
@@ -262,29 +297,29 @@ getHeader h =
 
 -- | Convert a WAI 'Wai.Response' into a hal
 -- 'HalResponse.ProxyResponse'.
-fromWaiResponse :: Wai.Response -> IO HalResponse.ProxyResponse
-fromWaiResponse (Wai.ResponseFile status headers path mFilePart) = do
+fromWaiResponse :: Options -> Wai.Response -> IO HalResponse.ProxyResponse
+fromWaiResponse opts (Wai.ResponseFile status headers path mFilePart) = do
   fileData <- readFilePart path mFilePart
   pure
     . addHeaders headers
     . HalResponse.response status
-    . createProxyBody (getContentType headers)
+    . createProxyBody opts (getContentType headers)
     $ fileData
-fromWaiResponse (Wai.ResponseBuilder status headers builder) =
+fromWaiResponse opts (Wai.ResponseBuilder status headers builder) =
   pure
     . addHeaders headers
     . HalResponse.response status
-    . createProxyBody (getContentType headers)
+    . createProxyBody opts (getContentType headers)
     . BL.toStrict
     $ Builder.toLazyByteString builder
-fromWaiResponse (Wai.ResponseStream status headers stream) = do
+fromWaiResponse opts (Wai.ResponseStream status headers stream) = do
   builderRef <- IORef.newIORef mempty
   let addChunk chunk = IORef.modifyIORef builderRef (<> chunk)
       flush = IORef.modifyIORef builderRef (<> Builder.flush)
   stream addChunk flush
   builder <- IORef.readIORef builderRef
-  fromWaiResponse (Wai.ResponseBuilder status headers builder)
-fromWaiResponse (Wai.ResponseRaw _ resp) = fromWaiResponse resp
+  fromWaiResponse opts (Wai.ResponseBuilder status headers builder)
+fromWaiResponse opts (Wai.ResponseRaw _ resp) = fromWaiResponse opts resp
 
 readFilePart :: FilePath -> Maybe Wai.FilePart -> IO ByteString
 readFilePart path mPart = withFile path ReadMode $ \h -> do
@@ -294,12 +329,12 @@ readFilePart path mPart = withFile path ReadMode $ \h -> do
       hSeek h AbsoluteSeek offset
       B.hGet h $ fromIntegral count
 
-createProxyBody :: Text -> ByteString -> HalResponse.ProxyBody
-createProxyBody contentType body
-  | any (`T.isPrefixOf` contentType) ["text/html", "text/plain", "application/json"] =
-    HalResponse.ProxyBody contentType (T.decodeUtf8 body) False
-  | otherwise =
+createProxyBody :: Options -> Text -> ByteString -> HalResponse.ProxyBody
+createProxyBody opts contentType body
+  | optionsBinaryMimeType opts contentType =
     HalResponse.ProxyBody contentType (T.decodeUtf8 $ B64.encode body) True
+  | otherwise =
+    HalResponse.ProxyBody contentType (T.decodeUtf8 body) False
 
 addHeaders ::
   ResponseHeaders -> HalResponse.ProxyResponse -> HalResponse.ProxyResponse

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -296,7 +296,7 @@ readFilePart path mPart = withFile path ReadMode $ \h -> do
 
 createProxyBody :: Text -> ByteString -> HalResponse.ProxyBody
 createProxyBody contentType body
-  | any (`T.isPrefixOf` contentType) ["text/plain", "application/json"] =
+  | any (`T.isPrefixOf` contentType) ["text/html", "text/plain", "application/json"] =
     HalResponse.ProxyBody contentType (T.decodeUtf8 body) False
   | otherwise =
     HalResponse.ProxyBody contentType (T.decodeUtf8 $ B64.encode body) True

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -156,7 +156,7 @@ defaultOptions = Options
 -- function exposes all the configurable knobs.
 runWithContext ::
   MonadIO m =>
-  -- | Configuration options, 'defaultOptions' provides sensible defaults.
+  -- | Configuration options. 'defaultOptions' provides sensible defaults.
   Options ->
   -- | We pass two 'Vault' keys to the callback that provides the
   -- 'Wai.Application'. This allows the application to look into the

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -31,9 +31,9 @@
 -- @
 module Network.Wai.Handler.Hal
   ( run,
+    runWithContext,
     Options (..),
     defaultOptions,
-    runWithContext,
     toWaiRequest,
     fromWaiResponse,
   )

--- a/test/Network/Wai/Handler/HalTest.hs
+++ b/test/Network/Wai/Handler/HalTest.hs
@@ -38,5 +38,5 @@ test_DefaultBinaryMimeTypes = testCase "default binary MIME types" $ do
   where
     assertBinary mime expected = assertEqual
       mime
-      (optionsBinaryMimeType defaultOptions (T.pack mime))
+      (binaryMimeType defaultOptions (T.pack mime))
       expected

--- a/test/Network/Wai/Handler/HalTest.hs
+++ b/test/Network/Wai/Handler/HalTest.hs
@@ -24,19 +24,20 @@ test_ConvertProxyRequest =
 
 test_DefaultBinaryMimeTypes :: TestTree
 test_DefaultBinaryMimeTypes = testCase "default binary MIME types" $ do
-  assertBinary "text/plain"               False
-  assertBinary "text/html"                False
-  assertBinary "application/json"         False
-  assertBinary "application/xml"          False
-  assertBinary "application/vnd.api+json" False
-  assertBinary "application/vnd.api+xml"  False
-  assertBinary "image/svg+xml"            False
+  assertBinary False "text/plain"
+  assertBinary False "text/html"
+  assertBinary False "application/json"
+  assertBinary False "application/xml"
+  assertBinary False "application/vnd.api+json"
+  assertBinary False "application/vnd.api+xml"
+  assertBinary False "image/svg+xml"
 
-  assertBinary "application/octet-stream" True
-  assertBinary "audio/vorbis"             True
-  assertBinary "image/png"                True
+  assertBinary True "application/octet-stream"
+  assertBinary True "audio/vorbis"
+  assertBinary True "image/png"
   where
-    assertBinary mime expected = assertEqual
-      mime
-      (binaryMimeType defaultOptions (T.pack mime))
-      expected
+    assertBinary expected mime =
+      assertEqual
+        mime
+        (binaryMimeType defaultOptions (T.pack mime))
+        expected

--- a/test/Network/Wai/Handler/HalTest.hs
+++ b/test/Network/Wai/Handler/HalTest.hs
@@ -4,11 +4,13 @@ module Network.Wai.Handler.HalTest where
 
 import AWS.Lambda.Events.ApiGateway.ProxyRequest
 import Data.Aeson (eitherDecodeFileStrict')
-import qualified Data.Text.Lazy.Encoding as T
+import qualified Data.Text as T
+import qualified Data.Text.Lazy.Encoding as TL
 import Data.Void (Void)
 import Network.Wai.Handler.Hal
 import Test.Tasty
 import Test.Tasty.Golden
+import Test.Tasty.HUnit (assertEqual, testCase)
 import Text.Pretty.Simple
 
 test_ConvertProxyRequest :: TestTree
@@ -17,5 +19,24 @@ test_ConvertProxyRequest =
     proxyRequest :: ProxyRequest Void <-
       eitherDecodeFileStrict' "test/data/ProxyRequest.json"
         >>= either fail pure
-    waiRequest <- toWaiRequest mempty 443 proxyRequest
-    pure . T.encodeUtf8 $ pShowNoColor waiRequest
+    waiRequest <- toWaiRequest defaultOptions proxyRequest
+    pure . TL.encodeUtf8 $ pShowNoColor waiRequest
+
+test_DefaultBinaryMimeTypes :: TestTree
+test_DefaultBinaryMimeTypes = testCase "default binary MIME types" $ do
+  assertBinary "text/plain"               False
+  assertBinary "text/html"                False
+  assertBinary "application/json"         False
+  assertBinary "application/xml"          False
+  assertBinary "application/vnd.api+json" False
+  assertBinary "application/vnd.api+xml"  False
+  assertBinary "image/svg+xml"            False
+
+  assertBinary "application/octet-stream" True
+  assertBinary "audio/vorbis"             True
+  assertBinary "image/png"                True
+  where
+    assertBinary mime expected = assertEqual
+      mime
+      (optionsBinaryMimeType defaultOptions (T.pack mime))
+      expected

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -77,6 +77,7 @@ test-suite wai-handler-hal-tests
     , pretty-simple    ^>=4.1.0.0
     , tasty            >=1.3      && <1.6
     , tasty-golden     ^>=2.3
+    , tasty-hunit      ^>=0.9
     , text
     , wai-handler-hal
 

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               wai-handler-hal
-version:            0.2.0.0
+version:            0.3.0.0
 synopsis:           Wrap WAI applications to run on AWS Lambda
 description:
   This library provides a function 'Network.Wai.Handler.Hal.run' to

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -54,7 +54,7 @@ common deps
     , hal                   >=0.4.7     && <0.4.11 || >=1.0.0 && <1.1
     , http-types            ^>=0.12.3
     , network               >=2.8.0.0   && <3.2
-    , text                  ^>=1.2.3    || >=2.0 && <2.1.1
+    , text                  ^>=1.2.3    || >=2.0   && <2.1.1
     , unordered-containers  ^>=0.2.10.0
     , vault                 ^>=0.3.1.0
     , wai                   ^>=3.2.2
@@ -73,11 +73,11 @@ test-suite wai-handler-hal-tests
   other-modules:      Network.Wai.Handler.HalTest
   build-tool-depends: tasty-discover:tasty-discover ^>=4.2.2
   build-depends:
-    , aeson            >=1.5.6.0  && <1.6 || >=2.0 && <2.3
+    , aeson            >=1.5.6.0  && <1.6  || >=2.0 && <2.3
     , pretty-simple    ^>=4.1.0.0
     , tasty            >=1.3      && <1.6
     , tasty-golden     ^>=2.3
-    , tasty-hunit      >=0.9
+    , tasty-hunit      >=0.9      && <0.11
     , text
     , wai-handler-hal
 

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -77,7 +77,7 @@ test-suite wai-handler-hal-tests
     , pretty-simple    ^>=4.1.0.0
     , tasty            >=1.3      && <1.6
     , tasty-golden     ^>=2.3
-    , tasty-hunit      ^>=0.9
+    , tasty-hunit      >=0.9
     , text
     , wai-handler-hal
 


### PR DESCRIPTION
I have an application running for the ZuriHac registration that used my own hacked-together lambda runtime -- I think `hal` didn't exist at the time.

I am in the process of porting this to `hal`, and found that I can't get plain HTML pages to render in the browser, they come out as base64-encoded versions.

Adding this Content-Type fixed it, but I wonder if we should not have the entirety of `text/` as a prefix?