### PR TITLE
Binary media types list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .dir-locals.el
+.direnv/
+.envrc
 dist-newstyle/
 dist/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for wai-handler-hal
 
+## 0.4.0.0 -- 2024-01-??
+
+- New function: `Wai.Handler.Hal.runWithOptions :: Options ->
+  Application -> ProxyRequest NoAuthorizer -> ProxyResponse`. This
+  provides a convenient way to pass custom `Options` without all the
+  bells and whistles of `runWithContext`.
 ## 0.3.0.0 -- 2023-12-17
 
 - Accidental breaking change: more elaborate `Content-Type` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.0.0 -- 2023-12-17
 
+- Accidental breaking change: more elaborate `Content-Type` headers
+  like `Content-Type: application/json; charset=utf-8` are now encoded
+  as if they were binary payloads. This release has been deprecated.
 - Breaking change: add `Options` record parameter to `runWithContext`,
   `toWaiRequest` and `fromWaiResponse`.
 - Provide a `defaultOptions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for wai-handler-hal
 
-## 0.4.0.0 -- 2024-01-??
+## 0.4.0.0 -- 2024-01-17
 
 - New function: `Wai.Handler.Hal.runWithOptions :: Options ->
   Application -> ProxyRequest NoAuthorizer -> ProxyResponse`. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
   Application -> ProxyRequest NoAuthorizer -> ProxyResponse`. This
   provides a convenient way to pass custom `Options` without all the
   bells and whistles of `runWithContext`.
+
+- Instead of guessing whether a given response `Content-Type` should
+  be sent as text or base64-encoded binary, `Options` now contains a
+  `binaryMediaTypes :: [MediaType]`, which lists the media types that
+  should be base64-encoded. This should match the `binaryMediaTypes`
+  setting you have configured on the API Gateway that integrates with
+  your Lambda Function.
+
+  _See:_ [Content type conversion in API
+    Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html)
+    in the [Amazon API Gateway Developer
+    Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/).
+
 ## 0.3.0.0 -- 2023-12-17
 
 - Accidental breaking change: more elaborate `Content-Type` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0.0 -- 2023-12-17
 
-- Breaking change: add `Options` record parameter to `runWithOptions`,
+- Breaking change: add `Options` record parameter to `runWithContext`,
   `toWaiRequest` and `fromWaiResponse`.
 - Provide a `defaultOptions`.
 - Make whether or not to run base64-encoding on the response body customizable

--- a/test/Network/Wai/Handler/HalTest.hs
+++ b/test/Network/Wai/Handler/HalTest.hs
@@ -19,7 +19,7 @@ import Network.Wai (Response, responseLBS)
 import Network.Wai.Handler.Hal
 import Test.Tasty (TestTree)
 import Test.Tasty.Golden (goldenVsString)
-import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.HUnit (Assertion, assertEqual)
 import Text.Pretty.Simple (pShowNoColor)
 
 test_ConvertProxyRequest :: TestTree
@@ -31,8 +31,8 @@ test_ConvertProxyRequest =
     waiRequest <- toWaiRequest defaultOptions proxyRequest
     pure . TL.encodeUtf8 $ pShowNoColor waiRequest
 
-test_BinaryResponse :: TestTree
-test_BinaryResponse = testCase "Responding to API Gateway with text" $ do
+unit_BinaryResponse :: Assertion
+unit_BinaryResponse = do
   let options = defaultOptions {binaryMediaTypes = ["*/*"]}
   ProxyResponse {body = ProxyBody {..}} <-
     fromWaiResponse options helloWorld
@@ -43,8 +43,8 @@ test_BinaryResponse = testCase "Responding to API Gateway with text" $ do
     (Right "Hello, World!")
     (B64.decode (T.encodeUtf8 serialized))
 
-test_TextResponse :: TestTree
-test_TextResponse = testCase "Responding to API Gateway with text" $ do
+unit_TextResponse :: Assertion
+unit_TextResponse = do
   ProxyResponse {body = ProxyBody {..}} <-
     fromWaiResponse defaultOptions helloWorld
 

--- a/test/Network/Wai/Handler/HalTest.hs
+++ b/test/Network/Wai/Handler/HalTest.hs
@@ -1,17 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Network.Wai.Handler.HalTest where
 
-import AWS.Lambda.Events.ApiGateway.ProxyRequest
+import AWS.Lambda.Events.ApiGateway.ProxyRequest (ProxyRequest)
+import AWS.Lambda.Events.ApiGateway.ProxyResponse
+  ( ProxyBody (..),
+    ProxyResponse (..),
+  )
 import Data.Aeson (eitherDecodeFileStrict')
-import qualified Data.Text as T
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy.Encoding as TL
 import Data.Void (Void)
+import Network.HTTP.Types (hContentType, ok200)
+import Network.Wai (Response, responseLBS)
 import Network.Wai.Handler.Hal
-import Test.Tasty
-import Test.Tasty.Golden
+import Test.Tasty (TestTree)
+import Test.Tasty.Golden (goldenVsString)
 import Test.Tasty.HUnit (assertEqual, testCase)
-import Text.Pretty.Simple
+import Text.Pretty.Simple (pShowNoColor)
 
 test_ConvertProxyRequest :: TestTree
 test_ConvertProxyRequest =
@@ -22,22 +31,25 @@ test_ConvertProxyRequest =
     waiRequest <- toWaiRequest defaultOptions proxyRequest
     pure . TL.encodeUtf8 $ pShowNoColor waiRequest
 
-test_DefaultBinaryMimeTypes :: TestTree
-test_DefaultBinaryMimeTypes = testCase "default binary MIME types" $ do
-  assertBinary False "text/plain"
-  assertBinary False "text/html"
-  assertBinary False "application/json"
-  assertBinary False "application/xml"
-  assertBinary False "application/vnd.api+json"
-  assertBinary False "application/vnd.api+xml"
-  assertBinary False "image/svg+xml"
+test_BinaryResponse :: TestTree
+test_BinaryResponse = testCase "Responding to API Gateway with text" $ do
+  let options = defaultOptions {binaryMediaTypes = ["*/*"]}
+  ProxyResponse {body = ProxyBody {..}} <-
+    fromWaiResponse options helloWorld
 
-  assertBinary True "application/octet-stream"
-  assertBinary True "audio/vorbis"
-  assertBinary True "image/png"
-  where
-    assertBinary expected mime =
-      assertEqual
-        mime
-        (binaryMimeType defaultOptions (T.pack mime))
-        expected
+  assertEqual "response is binary" True isBase64Encoded
+  assertEqual
+    "response is base64-encoded"
+    (Right "Hello, World!")
+    (B64.decode (T.encodeUtf8 serialized))
+
+test_TextResponse :: TestTree
+test_TextResponse = testCase "Responding to API Gateway with text" $ do
+  ProxyResponse {body = ProxyBody {..}} <-
+    fromWaiResponse defaultOptions helloWorld
+
+  assertEqual "response is not binary" False isBase64Encoded
+  assertEqual "response is unmangled" "Hello, World!" serialized
+
+helloWorld :: Response
+helloWorld = responseLBS ok200 [(hContentType, "text/plain")] "Hello, World!"

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               wai-handler-hal
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Wrap WAI applications to run on AWS Lambda
 description:
   This library provides a function 'Network.Wai.Handler.Hal.run' to

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -21,8 +21,9 @@ maintainer:         Bellroy Tech Team <haskell@bellroy.com>
 copyright:          Copyright (C) 2021 Bellroy Pty Ltd
 category:           AWS, Cloud
 build-type:         Simple
-extra-source-files:
+extra-doc-files:
   CHANGELOG.md
+extra-source-files:
   README.md
   test/data/ProxyRequest.json
   test/golden/WaiRequest.txt

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -52,6 +52,7 @@ common deps
     , bytestring            >=0.10.8    && <0.12.1
     , case-insensitive      ^>=1.2.0.0
     , hal                   >=0.4.7     && <0.4.11 || >=1.0.0 && <1.2
+    , http-media            ^>=0.8.1.1
     , http-types            ^>=0.12.3
     , network               >=2.8.0.0   && <3.2
     , text                  ^>=1.2.3    || >=2.0   && <2.1.1


### PR DESCRIPTION
A careful reading between the lines of the [API Gateway documentation][1] implies that if `binaryMediaTypes` is not set on the API Gateway, all responses are considered to be text. So we should be able to get away with an explicit list of media types that require binary responses, and we can ask the developer to ensure that it matches the `binaryMediaTypes` setting on his or her API.

Also document accidental breakage and improve ergonomics. @jaspervdj I'd be interested to hear if this works better for you than `0.3.0.0`.

[1]: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html