### PR TITLE
Allow ipv6 getaddrinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for wai-handler-hal
 
+## 0.4.0.1 -- 2025-02-19
+
+- When resolving source IPs, do not require `AF_INET` (IPv4)
+  addresses. This allows IPv6 source addresses to be passed through to
+  the underlying `wai` `Application`.
+
 ## 0.4.0.0 -- 2024-01-17
 
 - New function: `Wai.Handler.Hal.runWithOptions :: Options ->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.1 -- 2025-02-19
 
+- Use a `NonEmpty` list when consuming the result of `getAddrInfo`.
 - When resolving source IPs, do not require `AF_INET` (IPv4)
   addresses. This allows IPv6 source addresses to be passed through to
   the underlying `wai` `Application`.

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -59,6 +59,7 @@ import qualified Data.ByteString.Builder.Extra as Builder
 import qualified Data.ByteString.Lazy as LByteString
 import qualified Data.CaseInsensitive as CI
 import Data.Function ((&))
+import Data.Functor ((<&>))
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import qualified Data.IORef as IORef
@@ -270,9 +271,8 @@ toWaiRequest opts req = do
           sort
             . foldMap
               ( \(hName, hValues) ->
-                  (CI.map Text.encodeUtf8 hName,)
-                    . Text.encodeUtf8
-                    <$> hValues
+                  hValues <&> \hValue ->
+                    (CI.map Text.encodeUtf8 hName, Text.encodeUtf8 hValue)
               )
             . HashMap.toList
             $ HalRequest.multiValueHeaders req,

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -63,6 +63,7 @@ import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import qualified Data.IORef as IORef
 import Data.List (foldl', sort)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -244,7 +245,7 @@ toWaiRequest opts req = do
       (Just @IOException)
       (NS.getAddrInfo (Just hints) (Just sourceIp) (Just $ show port))
       >>= \case
-        Right (s : _) -> pure $ NS.addrAddress s
+        Right (s :| _) -> pure $ NS.addrAddress s
         _ -> do
           hPutStrLn stderr $
             mconcat

--- a/src/Network/Wai/Handler/Hal.hs
+++ b/src/Network/Wai/Handler/Hal.hs
@@ -229,7 +229,6 @@ toWaiRequest opts req = do
       hints =
         NS.defaultHints
           { NS.addrFlags = [NS.AI_NUMERICHOST],
-            NS.addrFamily = NS.AF_INET,
             NS.addrSocketType = NS.Stream
           }
       sourceIp =

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -56,7 +56,7 @@ common deps
     , hal                   >=0.4.7     && <0.4.11 || >=1.0.0 && <1.2
     , http-media            ^>=0.8.1.1
     , http-types            ^>=0.12.3
-    , network               >=2.8.0.0   && <3.3
+    , network               >=3.2.3.0   && <3.3
     , text                  ^>=1.2.3    || ^>=2.0  || ^>=2.1
     , unordered-containers  ^>=0.2.10.0
     , vault                 ^>=0.3.1.0


### PR DESCRIPTION
Remove from the `getAddrInfo` call the request that it should only return IPv4 addresses. We have started to see IPv6 addresses come through in requests from some AWS products, and this should silence the "Cannot convert sourceIp" that we're starting to see in logs.