### PR TITLE
Dependency updates 2026-04-14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1771297770,
-        "narHash": "sha256-tbFGVRLVytQGQgZZkJAwyge6ISpojHiR7TxQws51jBA=",
+        "lastModified": 1776127325,
+        "narHash": "sha256-0K6I/yPqeIXloD/RtesnyzrZ6ObTxZqcBXq+v2+w2T8=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "a52e52ca9a21bd32f45662f43fceca9e0b30fe48",
+        "rev": "2c0f359c5b8aee71dcb27274895e7547889c4be7",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770726378,
-        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771216249,
-        "narHash": "sha256-FNEmjUiwVcbaMx+DLNAPyEZMdw4ASGvEqJaswcJVRDc=",
+        "lastModified": 1775994940,
+        "narHash": "sha256-z5tkSIdPUs6IG3I9HD2e2stdzOKKh0qDeKkOURYQw6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7cdb2c9a4f4ec945cdd8348800b9205e5069b48f",
+        "rev": "9d600cdba342cea3b59aef50e093a547a0f4012f",
         "type": "github"
       },
       "original": {

--- a/wai-handler-hal.cabal
+++ b/wai-handler-hal.cabal
@@ -27,11 +27,7 @@ extra-source-files:
   test/data/ProxyRequest.json
   test/golden/WaiRequest.txt
 
-tested-with:
-  GHC ==9.6.7
-   || ==9.8.4
-   || ==9.10.3
-   || ==9.12.2
+tested-with:        GHC ==9.6.7 || ==9.8.4 || ==9.10.3 || ==9.12.2
 
 common opts
   default-language: Haskell2010
@@ -44,7 +40,7 @@ common opts
 
 common deps
   build-depends:
-    , base                  >=4.12      && <4.22
+    , base                  >=4.12      && <4.23
     , base64-bytestring     >=1.0.0.0   && <1.3
     , bytestring            >=0.10.8    && <0.13
     , case-insensitive      ^>=1.2.0.0
@@ -52,7 +48,7 @@ common deps
     , http-media            ^>=0.8.1.1
     , http-types            ^>=0.12.3
     , network               >=3.2.3.0   && <3.3
-    , text                  ^>=2.0  || ^>=2.1
+    , text                  ^>=2.0      || ^>=2.1
     , unordered-containers  ^>=0.2.10.0
     , vault                 ^>=0.3.1.0
     , wai                   ^>=3.2.2


### PR DESCRIPTION
## Summary
- Updated nix flake inputs (bellroy-nix-foss, git-hooks, nixpkgs)
- Bumped `base` upper bound to `<4.23` (supports GHC 9.14 / base 4.22)

## Test plan
- [x] CI passes across all supported GHC versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)